### PR TITLE
Update XRPL-NFT-Maker

### DIFF
--- a/docs/XRPL-NFT-Maker/ja/section-3/lesson-2_webアプリケーションからNFTをmintしよう.md
+++ b/docs/XRPL-NFT-Maker/ja/section-3/lesson-2_webアプリケーションからNFTをmintしよう.md
@@ -4,9 +4,10 @@
 
 このレッスンでは、アプリケーションをXummと連携し、NFTのMintトランザクションを実行する方法を学びます。
 
-- [Xummでのログインを実装しよう](#xummでのログインを実装しよう)
-- [画像のアップロードを実装しよう](#画像のアップロードを実装しよう)
-- [NFTのMint処理を実装しよう](#nftのmint処理を実装しよう)
+- [🏃 Xummでのログインを実装しよう](#-xummでのログインを実装しよう)
+- [🌥️ 画像のアップロードを実装しよう](#️-画像のアップロードを実装しよう)
+- [📝 NFTのMint処理を実装しよう](#-nftのmint処理を実装しよう)
+- [🙋‍♂️ 質問する](#️-質問する)
 
 ### 🏃 Xummでのログインを実装しよう
 
@@ -232,9 +233,9 @@ const mint = async () => {
       transaction: txid,
     });
     // トランザクション情報からNFTの情報を取得
-    const nftoken = extractAffectedNFT(txResponse);
-    alert('NFTトークンが発行されました！')
-    window.open(`https://test.bithomp.com/nft/${nftoken.NFTokenID}`, "_blank");
+    const nftokenId = txResponse.meta.nftoken_id
+    alert("NFTトークンが発行されました！");
+    window.open(`https://test.bithomp.com/nft/${nftokenId}`, "_blank");
   };
 ```
 
@@ -283,7 +284,7 @@ const mint = async () => {
 
 次に、この関数内で使うライブラリをインポートします。
 
-まずはコンソールで`npm install buffer@^6.0.3 xrpl-client@^2.0.11 nft.storage@^7.0.3 @xrplkit/txmeta@^1.2.0`を実行してください。
+まずはコンソールで`npm install buffer@^6.0.3 xrpl-client@^2.0.11 nft.storage@^7.0.3`を実行してください。
 
 `import { useEffect, useState } from "react";`の下に次のコードを追加してください。
 
@@ -291,7 +292,6 @@ const mint = async () => {
 import { Buffer } from "buffer";
 import { XrplClient } from 'xrpl-client'
 import { NFTStorage } from "nft.storage";
-import { extractAffectedNFT } from "@xrplkit/txmeta";
 ```
 
 また`const xumm = new Xumm("api-key");`の下に次のコードを追加してください。
@@ -377,9 +377,9 @@ mint関数の処理を1つずつ説明していきます。
       command: "tx",
       transaction: txid,
     });
-    const nftoken = extractAffectedNFT(txResponse);
-    alert('NFTトークンが発行されました！')
-    window.open(`https://test.bithomp.com/nft/${nftoken.NFTokenID}`, "_blank");
+    const nftokenId = txResponse.meta.nftoken_id
+    alert('NFTトークンが発行されました！');
+    window.open(`https://test.bithomp.com/nft/${nftokenId}`, "_blank");
 ```
 
 > **✅ テストを実行してみよう**

--- a/docs/XRPL-NFT-Maker/ja/section-4/lesson-1_Webアプリをアップデートしよう.md
+++ b/docs/XRPL-NFT-Maker/ja/section-4/lesson-1_Webアプリをアップデートしよう.md
@@ -14,10 +14,9 @@ import { useEffect, useState } from "react";
 import { Buffer } from "buffer";
 import { XrplClient } from 'xrpl-client'
 import { NFTStorage } from "nft.storage";
-import { extractAffectedNFT } from "@xrplkit/txmeta";
 
 const xumm = new Xumm("apikey");
-const nftStorage = new NFTStorage({  token: 'token'});
+const nftStorage = new NFTStorage({ token: 'token' });
 
 export const NftMinter = () => {
   const [account, setAccount] = useState(undefined);
@@ -72,9 +71,9 @@ export const NftMinter = () => {
       command: "tx",
       transaction: txid,
     });
-    const nftoken = extractAffectedNFT(txResponse);
-    alert('NFTトークンが発行されました！')
-    window.open(`https://test.bithomp.com/nft/${nftoken.NFTokenID}`, "_blank");
+    const nftokenId = txResponse.meta.nftoken_id
+    alert("NFTトークンが発行されました！");
+    window.open(`https://test.bithomp.com/nft/${nftokenId}`, "_blank");
   };
 
   return (


### PR DESCRIPTION
## 変更内容

- `@xrplkit/txmeta`を用いたNFTokenIDの取得処理を削除
- トランザクションの結果を保持するtxResponse変数から直接`nftoken_id`を取得するよう変更

## 背景

XRPLのノードがv1.11.0により`NFTokenMint`トランザクションのTxResponseに`nftoken_id`フィールドが含まれるようになったため。

## 備考

[v1.11.0](https://xrpl.org/blog/2023/rippled-1.11.0.html)
<!-- 影響範囲など -->
