### PR TITLE
limit textlint to japanese documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/unchain-dev/UNCHAIN-projects.git",
   "author": "SHØ <neila@users.noreply.github.com> (https://akxra.art/)",
   "scripts": {
-    "textlint:check": "textlint docs/**/*.md --ignore-path .textlintignore",
-    "textlint:fix": "textlint --fix docs/**/*.md --ignore-path .textlintignore",
+    "textlint:check": "textlint docs/*/ja/**/*.md --ignore-path .textlintignore",
+    "textlint:fix": "textlint --fix docs/*/ja/**/*.md --ignore-path .textlintignore",
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {


### PR DESCRIPTION
## 変更内容
- textlintの実行を日本語コンテンツ（`docs/*/ja/**`）に限定

## 背景
- #435 をきっかけに日本語以外のコンテンツが追加され、その際にCIが不要にエラーを吐くため

## 備考

<!-- 該当ページの URL -->
<!-- 影響範囲など -->
