### PR TITLE
ディレクトリ表記でsrc階層が不足していたため修正

### DIFF
--- a/docs/ICP-Encrypted-Notes/ja/section-1/lesson-1_ノートの管理機能を実装しよう.md
+++ b/docs/ICP-Encrypted-Notes/ja/section-1/lesson-1_ノートの管理機能を実装しよう.md
@@ -4,13 +4,14 @@
 
 ### 🛠 バックエンドキャニスターの実装
 
-早速ですが、バックエンドキャニスターにノートを管理する機能を実装していきましょう。まずは、`encrypted_notes_backend/src/`下に`notes.rs`を作成します。
+早速ですが、バックエンドキャニスターにノートを管理する機能を実装していきましょう。まずは、`src/encrypted_notes_backend/src/`下に`notes.rs`を作成します。
 
 ```diff
-encrypted_notes_backend/
-└── src/
-    ├── lib.rs
-+   └── notes.rs
+src/
+└── encrypted_notes_backend/
+    └── src/
+        ├── lib.rs
++       └── notes.rs
 ```
 
 作成した`notes.rs`の先頭に、[use](https://doc.rust-lang.org/std/keyword.use.html)キーワードでファイル内で使用したい機能をインポートします。


### PR DESCRIPTION
## 変更内容
コンテンツ：ICP-Encrypted-Notes, section-1, lesson-1
ディレクトリ表記でsrc階層が不足していたため修正

## before
まずは、`encrypted_notes_backend/src/`下に`notes.rs`を作成します。
```diff
encrypted_notes_backend/
└── src/
    ├── lib.rs
+   └── notes.rs
```

## after
まずは、`src/encrypted_notes_backend/src/`下に`notes.rs`を作成します。
```diff
src/
└── encrypted_notes_backend/
    └── src/
        ├── lib.rs
+       └── notes.rs
```
