### PR TITLE
Ownableコンストラクタの初期化を追加

### DIFF
--- a/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
@@ -103,7 +103,7 @@ contract Shield is ERC721Enumerable, Ownable {
       * Constructor for Shields takes in the baseURI to set _baseTokenURI for the collection.
       * It also initializes an instance of whitelist interface.
       */
-    constructor (string memory baseURI, address whitelistContract) ERC721("ChainIDE Shields", "CS") {
+    constructor (string memory baseURI, address whitelistContract) ERC721("ChainIDE Shields", "CS") Ownable(msg.sender) {
         _baseTokenURI = baseURI;
         _whitelist = IWhitelist(whitelistContract);
     }


### PR DESCRIPTION
## 変更内容
`Shield`コントラクトが継承している`Ownable`コントラクトの初期化処理が無いため追加した。

## 背景
Section 2 > Lesson 2 にて、`Ownable`のSolidityバージョンが`^0.8.20`であったため、コンパイラのバージョンを　19 → 20 にあげた。すると、`Ownable`コントラクトが初期化されていないためにコンパイルエラーが出た。下記の通り、`Ownable`コントラクトには初期化が必要なコンストラクタがあるため、初期化処理を追加した。
```solidity
// SPDX-License-Identifier: MIT
// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)

pragma solidity ^0.8.20;

abstract contract Ownable is Context {

...

    /**
    * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
    */
    constructor(address initialOwner) {
        if (initialOwner == address(0)) {
            revert OwnableInvalidOwner(address(0));
        }
        _transferOwnership(initialOwner);
    }

...

}
```

## 備考
- [該当ページの URL](https://app.unchain.tech/learn/Polygon-Whitelist-NFT/ja/2/2/)
<!-- 影響範囲など -->
