### PR TITLE
Feature/Polygon Whitelist NFT/update openzeppelin

### DIFF
--- a/docs/Polygon-Whitelist-NFT/en/section-1/lesson-2_Basic Coding.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-1/lesson-2_Basic Coding.md
@@ -16,7 +16,7 @@ In `Whitelist.sol`, let's start with a simple block of code.
 ```solidity
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 contract Whitelist {
     constructor() {
@@ -33,10 +33,10 @@ Let's talk about the code line by line.
 This line is referred to `SPDX license identifier`, which addresses the copyright issues of the code that follows. Generally speaking, `UNLICENSED` and `MIT` are the most common suffixes, indicating that the following code is permitted for anyone to use. In other words, you all can freely copy and paste it. You can find more information [here](https://spdx.org/licenses/).
 
 ```solidity
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 ```
 
-This specifies the version of the Solidity compiler that we want the contract to use. It means that only a Solidity compiler with a version between `0.8.4` and `0.9.0` can be used to compile the code.
+This specifies the version of the Solidity compiler that we want the contract to use. It means that only a Solidity compiler with a version between `0.8.20` and `0.9.0` can be used to compile the code.
 
 ```solidity
 contract Whitelist {

--- a/docs/Polygon-Whitelist-NFT/en/section-1/lesson-3_Whitelist Function.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-1/lesson-3_Whitelist Function.md
@@ -6,7 +6,7 @@ The basic knowledge about smart contracts is ready. Let's update the `Whitelist.
 
 ```solidity
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 contract Whitelist {
     // The address that can operate addAddressToWhitelist function

--- a/docs/Polygon-Whitelist-NFT/en/section-2/lesson-2_Mint Function.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-2/lesson-2_Mint Function.md
@@ -48,7 +48,7 @@ We'll insert the following code into the `IWhitelist.sol`.
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 interface IWhitelist {
     function whitelistedAddresses(address) external view returns (bool);
@@ -64,7 +64,7 @@ We insert the code below in `Shield.sol`.
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -154,7 +154,7 @@ Don't worry, lets talk about this contract step by step.
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/docs/Polygon-Whitelist-NFT/en/section-2/lesson-2_Mint Function.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-2/lesson-2_Mint Function.md
@@ -103,7 +103,7 @@ contract Shield is ERC721Enumerable, Ownable {
       * Constructor for Shields takes in the baseURI to set _baseTokenURI for the collection.
       * It also initializes an instance of whitelist interface.
       */
-    constructor (string memory baseURI, address whitelistContract) ERC721("ChainIDE Shields", "CS") {
+    constructor (string memory baseURI, address whitelistContract) ERC721("ChainIDE Shields", "CS") Ownable(msg.sender) {
         _baseTokenURI = baseURI;
         _whitelist = IWhitelist(whitelistContract);
     }

--- a/docs/Polygon-Whitelist-NFT/en/section-5/lesson-1_Monorepo configration.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-5/lesson-1_Monorepo configration.md
@@ -151,7 +151,7 @@ import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.4',
+  solidity: '0.8.20',
   paths: {
     artifacts: '../client/artifacts',
   },

--- a/docs/Polygon-Whitelist-NFT/en/section-5/lesson-1_Monorepo configration.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-5/lesson-1_Monorepo configration.md
@@ -81,7 +81,7 @@ Verify that hardhat has been added to packages/contract/package.json. If the ins
 Next, install the necessary tools. As before, run the following command in the root of the project.
 
 ```
-yarn workspace contract add @openzeppelin/contracts@^4.8.2 && yarn workspace contract add --dev @nomicfoundation/hardhat-chai-matchers@^1.0.0 @nomicfoundation/hardhat-network-helpers@^1.0.8 @nomicfoundation/hardhat-toolbox@^2.0.1 @nomiclabs/hardhat-ethers@^2.0.0 @nomiclabs/hardhat-etherscan@^3.0.0 @typechain/ethers-v5@^10.1.0 @typechain/hardhat@^6.1.2 @types/chai@^4.2.0 @types/mocha@^9.1.0 chai@^4.3.7 hardhat-gas-reporter@^1.0.8 solidity-coverage@^0.8.1 ts-node@^8.0.0 typechain@^8.1.0 typescript@^4.5.0
+yarn workspace contract add @openzeppelin/contracts@^5.0.0 && yarn workspace contract add --dev @nomicfoundation/hardhat-chai-matchers@^1.0.0 @nomicfoundation/hardhat-network-helpers@^1.0.8 @nomicfoundation/hardhat-toolbox@^2.0.1 @nomiclabs/hardhat-ethers@^2.0.0 @nomiclabs/hardhat-etherscan@^3.0.0 @typechain/ethers-v5@^10.1.0 @typechain/hardhat@^6.1.2 @types/chai@^4.2.0 @types/mocha@^9.1.0 chai@^4.3.7 hardhat-gas-reporter@^1.0.8 solidity-coverage@^0.8.1 ts-node@^8.0.0 typechain@^8.1.0 typescript@^4.5.0
 ```
 
 At this point, packages/contract/package.json should look like the following.

--- a/docs/Polygon-Whitelist-NFT/en/section-5/lesson-2_Automated contract testing.md
+++ b/docs/Polygon-Whitelist-NFT/en/section-5/lesson-2_Automated contract testing.md
@@ -161,9 +161,9 @@ describe('Shield', function () {
         const { shield, alice } = await loadFixture(deployWhitelistFixture);
 
         // Verify that an account that is not the owner of the contract will get an error if it tries to execute the setPaused function.
-        await expect(shield.connect(alice).setPaused(true)).to.be.revertedWith(
-          'Ownable: caller is not the owner',
-        );
+        await expect(shield.connect(alice).setPaused(true))
+          .to.be.revertedWithCustomError(shield, 'OwnableUnauthorizedAccount')
+          .withArgs(alice.address);
       });
     });
     context('when set to true', function () {
@@ -280,9 +280,9 @@ describe('Shield', function () {
         const { shield, alice } = await loadFixture(deployWhitelistFixture);
 
         // Verify that an error occurs when an account that is not the owner of the contract tries to execute the withdraw function.
-        await expect(shield.connect(alice).withdraw()).to.be.revertedWith(
-          'Ownable: caller is not the owner',
-        );
+        await expect(shield.connect(alice).withdraw())
+          .to.be.revertedWithCustomError(shield, 'OwnableUnauthorizedAccount')
+          .withArgs(alice.address);
       });
     });
     context('when owner executes', function () {

--- a/docs/Polygon-Whitelist-NFT/ja/section-1/lesson-2_基本的なコーディング.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-1/lesson-2_基本的なコーディング.md
@@ -17,7 +17,7 @@
 ```solidity
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 contract Whitelist {
     constructor() {
@@ -34,10 +34,10 @@ contract Whitelist {
 この行は`SPDXライセンス識別子`と呼ばれ、その後に続くコードの著作権の問題に対処します。一般的には、`UNLICENSED`と`MIT`が最もよく使われる接尾辞で、これは以下のコードが誰でも使ってよいことを示します。言い換えれば、皆さんは自由にコピー&ペーストすることができます。詳細は[こちら](https://spdx.org/licenses/)で確認できます。
 
 ```solidity
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 ```
 
-これは、コントラクトに使用するSolidityコンパイラのバージョンを指定します。`0.8.4`から`0.9.0`の間のバージョンのSolidityコンパイラのみが使用できることを意味します。
+これは、コントラクトに使用するSolidityコンパイラのバージョンを指定します。`0.8.20`から`0.9.0`の間のバージョンのSolidityコンパイラのみが使用できることを意味します。
 
 ```solidity
 contract Whitelist {

--- a/docs/Polygon-Whitelist-NFT/ja/section-1/lesson-3_ホワイトリスト機能.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-1/lesson-3_ホワイトリスト機能.md
@@ -6,7 +6,7 @@
 
 ```solidity
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 contract Whitelist {
     // The address that can operate addAddressToWhitelist function

--- a/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
@@ -47,7 +47,7 @@ Whitelistコントラクトでは、オーナーアドレスを設定し、`requ
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 interface IWhitelist {
     function whitelistedAddresses(address) external view returns (bool);
@@ -64,7 +64,7 @@ interface IWhitelist {
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -155,7 +155,7 @@ contract Shield is ERC721Enumerable, Ownable {
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
@@ -81,7 +81,7 @@ packages/contract/package.jsonにhardhatが追加されていることを確認�
 次に必要なツールをインストールします。先ほどと同様に、プロジェクトのルートで下記のコマンドを実行してください。
 
 ```
-yarn workspace contract add @openzeppelin/contracts@^4.8.2 && yarn workspace contract add --dev @nomicfoundation/hardhat-chai-matchers@^1.0.0 @nomicfoundation/hardhat-network-helpers@^1.0.8 @nomicfoundation/hardhat-toolbox@^2.0.1 @nomiclabs/hardhat-ethers@^2.0.0 @nomiclabs/hardhat-etherscan@^3.0.0 @typechain/ethers-v5@^10.1.0 @typechain/hardhat@^6.1.2 @types/chai@^4.2.0 @types/mocha@^9.1.0 chai@^4.3.7 hardhat-gas-reporter@^1.0.8 solidity-coverage@^0.8.1 ts-node@^8.0.0 typechain@^8.1.0 typescript@^4.5.0
+yarn workspace contract add @openzeppelin/contracts@^5.0.0 && yarn workspace contract add --dev @nomicfoundation/hardhat-chai-matchers@^1.0.0 @nomicfoundation/hardhat-network-helpers@^1.0.8 @nomicfoundation/hardhat-toolbox@^2.0.1 @nomiclabs/hardhat-ethers@^2.0.0 @nomiclabs/hardhat-etherscan@^3.0.0 @typechain/ethers-v5@^10.1.0 @typechain/hardhat@^6.1.2 @types/chai@^4.2.0 @types/mocha@^9.1.0 chai@^4.3.7 hardhat-gas-reporter@^1.0.8 solidity-coverage@^0.8.1 ts-node@^8.0.0 typechain@^8.1.0 typescript@^4.5.0
 ```
 
 ここまでで、packages/contract/package.jsonは下記のようになっているはずです。

--- a/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
@@ -151,7 +151,7 @@ import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.4',
+  solidity: '0.8.20',
   paths: {
     artifacts: '../client/artifacts',
   },

--- a/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-2_コントラクトの自動テスト.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-2_コントラクトの自動テスト.md
@@ -161,9 +161,9 @@ describe('Shield', function () {
         const { shield, alice } = await loadFixture(deployWhitelistFixture);
 
         // コントラクトのオーナーではないアカウントが、setPaused関数を実行しようとするとエラーとなることを確認します。
-        await expect(shield.connect(alice).setPaused(true)).to.be.revertedWith(
-          'Ownable: caller is not the owner',
-        );
+        await expect(shield.connect(alice).setPaused(true))
+          .to.be.revertedWithCustomError(shield, 'OwnableUnauthorizedAccount')
+          .withArgs(alice.address);
       });
     });
     context('when set to true', function () {
@@ -280,9 +280,9 @@ describe('Shield', function () {
         const { shield, alice } = await loadFixture(deployWhitelistFixture);
 
         // コントラクトのオーナーではないアカウントが、withdraw関数を実行しようとするとエラーとなることを確認します。
-        await expect(shield.connect(alice).withdraw()).to.be.revertedWith(
-          'Ownable: caller is not the owner',
-        );
+        await expect(shield.connect(alice).withdraw())
+          .to.be.revertedWithCustomError(shield, 'OwnableUnauthorizedAccount')
+          .withArgs(alice.address);
       });
     });
     context('when owner executes', function () {


### PR DESCRIPTION
## 変更内容
- solidityコンパイラバージョンをv0.8.20に更新
- monorepo構築時の`@openzeppelin/contracts`バージョンをv5.0.0に更新
- テストスクリプトの更新

## 背景
@openzeppelin/contractsのv5.0.0リリースに伴い、OwnableのSolidityコンパイラバージョン・仕様が更新されたため
（https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v5.0.0）

### ChainIDE上で確認したエラー

- ChainIDE上で用いられるopenzeppelin/contractsが`v5.0.0`に
<img width="880" alt="Screen Shot 2023-10-12 at 11 46 21" src="https://github.com/unchain-tech/UNCHAIN-projects/assets/60546319/ea00b577-8424-49d8-a0b3-496cf4bd78fb">

- 上記に伴い、Ownableの明示的な初期化が必要に
<img width="877" alt="Screen Shot 2023-10-12 at 11 47 21" src="https://github.com/unchain-tech/UNCHAIN-projects/assets/60546319/1bd64f4f-ee23-48e1-9a50-39992d6fee76">

## 備考

<!-- 該当ページの URL -->
<!-- 影響範囲など -->
