### PR TITLE
fix: unaccessible domain

### DIFF
--- a/docs/ICP-Static-Site/ja/section-4/lesson-1_チェーン上にデプロイをしよう.md
+++ b/docs/ICP-Static-Site/ja/section-4/lesson-1_チェーン上にデプロイをしよう.md
@@ -66,7 +66,7 @@ Deployed canisters.
 
 それでは、デプロイしたポートフォリオサイトにアクセスしてみましょう。URLはキャニスター IDを用いたものになります。
 
-`https://<CREATED_CANISTER_ID>.ic0.app/`
+`https://<CREATED_CANISTER_ID>.icp0.io/`
 
 キャニスター IDは、デプロイ時の出力や生成された`canister_ids.json`ファイル、または以下のコマンドで確認できます。
 


### PR DESCRIPTION
## 変更内容
[https://app.unchain.tech/learn/ICP-Static-Site/ja/4/1/](url) で提示されているポートフォリオのURLを`https://<CREATED_CANISTER_ID>.ic0.app/` から `https://<CREATED_CANISTER_ID>.icp0.io/` に変更しました。
## 背景
変更前のURL `https://<CREATED_CANISTER_ID>.ic0.app/` からポートフォリオへアクセスしたところ `404 Not Found` と表示されました。
以下の公式サイトを見たところ、今年の4/20を境に、新規で作成された canisterは `icp0.io` ドメインでのみアクセス可能となったようです。
[https://forum.dfinity.org/t/follow-up-on-item-new-canisters-will-only-be-accessible-through-the-icp0-io-domain-existing-canisters-will-be-accessible-both-through-ic0-app-and-icp0-io/18889](url)