### PR TITLE
fix: typo

### DIFF
--- a/docs/ICP-Encrypted-Notes/ja/section-1/lesson-2_インタフェースを定義しよう.md
+++ b/docs/ICP-Encrypted-Notes/ja/section-1/lesson-2_インタフェースを定義しよう.md
@@ -4,7 +4,7 @@
 
 #### Candidとは
 
-Candidは、サービスのパブリック・インタフェースを記述することを主な目的としたインタフェース記述言語です。Candidの主な利点のひとつは、言語にとらわれず、Motoko[https://internetcomputer.org/docs/current/motoko/main/about-this-guide]、Rust、JavaScriptなどの異なるプログラミング言語で書かれたサービスとフロントエンド間の相互運用を可能にすることです。詳細は[こちら](https://internetcomputer.org/docs/current/developer-docs/backend/candid/candid-concepts)をご覧ください。
+Candidは、サービスのパブリック・インタフェースを記述することを主な目的としたインタフェース記述言語です。Candidの主な利点のひとつは、言語にとらわれず、[Motoko](https://internetcomputer.org/docs/current/motoko/main/about-this-guide)、Rust、JavaScriptなどの異なるプログラミング言語で書かれたサービスとフロントエンド間の相互運用を可能にすることです。詳細は[こちら](https://internetcomputer.org/docs/current/developer-docs/backend/candid/candid-concepts)をご覧ください。
 
 Motokoでキャニスターを記述した場合、プログラムをコンパイルする際にコンパイラが自動的にCandidで記述されたファイル`.did`を生成してくれます。しかし、Rustでは2023年9月時点でそのような機能は組み込まれておらず、Candidインタフェースを自動生成するためには設定が必要です。
 


### PR DESCRIPTION
## 変更内容
`Motoko[<リンク>]` から `[Motoko](<リンク>)` へ変更しました。
## 背景
[ICP-Encrypted-Notes 1-2](https://app.unchain.tech/learn/ICP-Encrypted-Notes/ja/1/2/) の `Candidとは` にて表示崩れがありました。
## 備考
VSCodeのMarkdownプレビューだと `Motoko[<リンク>]` のように書いたまま表示されていましたが、Webサイトの方だと本文の方までリンク化されてしまうようです。
<!-- 該当ページの URL -->
<!-- 影響範囲など -->
