### PR TITLE
[Polygon-Whitelist-NFT]参照先コントラクトとレイアウト崩れを修正

### DIFF
--- a/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-2/lesson-2_ミント機能.md
@@ -246,7 +246,7 @@ contract Shield is ERC721Enumerable, Ownable {
 
 5. `tokenIds += 1;`：上記すべての条件が満たされた後で、`tokenIds`は1増加します。デフォルトの`tokenIds`値は0なので、`tokenIds`の範囲は1, 2, 3, 4となります。
 
-6. `_safeMint(msg.sender, tokenIds);`：この機能は`"@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol"`によって実装されています。そのコントラクトを参照することで具体的な機能を確認することができます。今のところ、この関数を呼び出した人にNFTがミントされるということだけ理解しておけば良いです。
+6. `_safeMint(msg.sender, tokenIds);`：この機能は`"@openzeppelin/contracts/token/ERC721/ERC721.sol"`によって実装されています。そのコントラクトを参照することで具体的な機能を確認することができます。今のところ、この関数を呼び出した人にNFTがミントされるということだけ理解しておけば良いです。
 
 ```solidity
     /**

--- a/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
+++ b/docs/Polygon-Whitelist-NFT/ja/section-5/lesson-1_モノレポの設定.md
@@ -140,8 +140,7 @@ npx hardhat
 まずは、プロジェクトのルートにあるcontractsフォルダを`packages/contract`フォルダ内に移動しましょう。下記のコマンドは、プロジェクトのルートで実行してください。
 
 ```
-rm -r ./packages/contract/contracts/ && mv ./cont
-contracts/ ./packages/contract/
+rm -r ./packages/contract/contracts/ && mv ./contracts/ ./packages/contract/
 ```
 
 次に、`hardhat.config.ts`を下記のように更新しましょう。


### PR DESCRIPTION
## 変更内容
- Section2 > Lesson2：説明に記載されている参照先コントラクトを修正
- Section5 > Lesson1：bashコマンドのレイアウト崩れを修正

## 背景
- Section2 > Lesson2：説明に記載されている参照先コントラクトを修正
  - `_safeMint(msg.sender, tokenIds)`の実装は`ERC721/extensions/ERC721Enumerable.sol`ではなく`ERC721/ERC721.sol`であるため、コントラクト名を修正した
