### PR TITLE
Feature/Polygon ENS Domain/remove console

### DIFF
--- a/docs/Polygon-ENS-Domain/ja/section-3/lesson-1_資金の引き出しを実装しよう.md
+++ b/docs/Polygon-ENS-Domain/ja/section-3/lesson-1_資金の引き出しを実装しよう.md
@@ -18,7 +18,7 @@
 
 ```solidity
 modifier onlyOwner() {
-    require(isOwner());
+    require(isOwner(), "You aren't the owner");
     _;
 }
 

--- a/docs/Polygon-ENS-Domain/ja/section-3/lesson-2_理解を深めよう.md
+++ b/docs/Polygon-ENS-Domain/ja/section-3/lesson-2_理解を深めよう.md
@@ -167,18 +167,13 @@ describe('ENS-Domain', () => {
       deployTextFixture,
     );
 
-    let txn;
-
     const ownerBeforeBalance = await hre.ethers.provider.getBalance(
       owner.address,
     );
-    // スーパーコーダーとしてコントラクトから資金を奪おうとします。
-    try {
-      txn = await domainContract.connect(superCoder).withdraw();
-      await txn.wait();
-    } catch (error) {
-      console.log('robber could not withdraw token');
-    }
+
+    await expect(
+      domainContract.connect(superCoder).withdraw(),
+    ).to.be.revertedWith("You aren't the owner");
 
     const ownerAfterBalance = await hre.ethers.provider.getBalance(
       owner.address,

--- a/docs/Polygon-ENS-Domain/ja/section-3/lesson-2_理解を深めよう.md
+++ b/docs/Polygon-ENS-Domain/ja/section-3/lesson-2_理解を深めよう.md
@@ -14,11 +14,9 @@ mapping(uint => string) public names;
 
 // コントラクトのどこかに付け加えてください。
 function getAllNames() public view returns (string[] memory) {
-    console.log("Getting all names from contract");
     string[] memory allNames = new string[](_tokenIds.current());
     for (uint i = 0; i < _tokenIds.current(); i++) {
         allNames[i] = names[i];
-        console.log("Name for token %d is %s", i, allNames[i]);
     }
 
     return allNames;
@@ -225,6 +223,41 @@ describe('ENS-Domain', () => {
 
 ```
 
+次に、`Domains`コントラクト内で定義していた`console.log`を削除しましょう。
+
+import文を削除します。
+
+```solidity
+// === 下記を削除 ===
+import "hardhat/console.sol";
+```
+
+constructor関数内の`console.log`を削除します。
+
+```solidity
+    // === 下記を削除 ===
+    console.log('%s name service deployed', _tld);
+```
+
+`register`関数内の`console.log`を削除します。
+
+```solidity
+    // === 下記を削除 ===
+    console.log(
+      'Registering %s.%s on the contract with tokenID %d',
+      name,
+      tld,
+      newRecordId
+    );
+```
+
+```solidity
+    // === 下記を削除 ===
+    console.log('\n--------------------------------------------------------');
+    console.log('Final tokenURI', finalTokenUri);
+    console.log('--------------------------------------------------------\n');
+```
+
 では下のコマンドを実行することでコントラクトのテストをしていきましょう！
 
 ```
@@ -234,16 +267,18 @@ yarn test
 最後に下のような結果がでいれば成功です！
 
 ```
-    ✔ Token amount contract has is correct! (4986ms)
-robber could not withdraw token
-    ✔ someone not owenr cannot withdraw token (68ms)
+Compiled 1 Solidity file successfully
+
+
+  ENS-Domain
+    ✔ Token amount contract has is correct! (1417ms)
+    ✔ someone not owenr cannot withdraw token
     ✔ contract owner can withdrawl token from conteract!
-    ✔ Domain value is depend on how long it is (38ms)
+    ✔ Domain value is depend on how long it is
 
 
-  4 passing (5s)
+  4 passing (1s)
 
-✨  Done in 8.83s.
 ```
 
 ### 🙋‍♂️ 質問する


### PR DESCRIPTION
## 変更内容
学習コンテンツ`Polygon ENS Domain`のコントラクトとテストスクリプトに定義されていた`console.log`を削除しました。

## 背景
PR: https://github.com/unchain-tech/Polygon-ENS-Domain/issues/7 による見本コンテンツ更新のため

## 備考

<!-- 該当ページの URL -->
<!-- 影響範囲など -->
